### PR TITLE
Fix/#79  토큰 재발급 문제 해결

### DIFF
--- a/src/main/java/com/study/studyproject/global/config/SpringSecurity.java
+++ b/src/main/java/com/study/studyproject/global/config/SpringSecurity.java
@@ -5,28 +5,19 @@ import com.study.studyproject.global.jwt.JwtAccessDeniedHandler;
 import com.study.studyproject.global.jwt.JwtAuthenticationEntryPoint;
 import com.study.studyproject.global.jwt.JwtFilter;
 import com.study.studyproject.global.jwt.JwtUtil;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.channel.ChannelProcessingFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
@@ -50,15 +41,18 @@ public class SpringSecurity {
         return web -> web.ignoring().requestMatchers("/h2-console/**"); //제외될 url
     }
 
-    private final CorsFilter filter;
-    private final  CorsConfig corsConfig;
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(jwtUtil); // JwtFilter를 빈으로 등록
+    }
 
+
+    private final CorsFilter filter;
     private final JwtUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.addFilter(filter);
-        http.addFilterBefore(new JwtFilter(jwtUtil),CorsFilter.class);
         http.csrf(AbstractHttpConfigurer::disable) //
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 생성x
                 .formLogin(f -> f.disable())
@@ -79,10 +73,13 @@ public class SpringSecurity {
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll()
         );
+        http.addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
 
     }
+
 
 
 }

--- a/src/main/java/com/study/studyproject/global/exception/ExceptionResponse.java
+++ b/src/main/java/com/study/studyproject/global/exception/ExceptionResponse.java
@@ -1,12 +1,10 @@
 package com.study.studyproject.global.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.Date;
+import static com.study.studyproject.global.exception.ex.ErrorCode.INTERNAL_SEVER_ERROR;
 
 @Data
 @NoArgsConstructor
@@ -18,5 +16,12 @@ public class ExceptionResponse {
     public ExceptionResponse(int status, String message) {
         this.status = status;
         this.message = message;
+    }
+
+    public static ExceptionResponse of(int status, String message) {
+        return ExceptionResponse.builder()
+                .message(message)
+                .status(status)
+                .build();
     }
 }

--- a/src/main/java/com/study/studyproject/global/exception/advice/ExControllerAdvice.java
+++ b/src/main/java/com/study/studyproject/global/exception/advice/ExControllerAdvice.java
@@ -5,17 +5,18 @@ import com.study.studyproject.global.exception.ex.BusinessException;
 import com.study.studyproject.global.exception.ex.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.study.studyproject.global.exception.ex.ErrorCode.INTERNAL_SEVER_ERROR;
@@ -40,23 +41,27 @@ public class ExControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.internalServerError().body(errorResponse);
     }
 
-    // Bean
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException exception,
+            HttpHeaders headers, HttpStatusCode status, WebRequest request
+    ) {
+        log.error("error :{}" ,exception.getParameterName());
+        return ResponseEntity.badRequest().body(ExceptionResponse.of(HttpStatus.BAD_REQUEST.value(),exception.getParameterName() + "은 NULL일 수 없습니다."));
+    }
+
+
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
                                                                   HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("status", status.value());
 
         Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getAllErrors().forEach((error) -> {
-            String fieldName = ((FieldError) error).getField();
-            String errorMessage = error.getDefaultMessage();
-            body.put(fieldName, errorMessage);
-        });
+        ex.getBindingResult().getAllErrors()
+                .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
+        log.error("error :{}" ,errors);
 
-
-
-        return new ResponseEntity<>(body, headers, status);
+        return ResponseEntity.status(status.value()).body(errors);
     }
 
     private ResponseEntity<ExceptionResponse> createErrorResponse(ErrorCode errorCode) {

--- a/src/main/java/com/study/studyproject/global/exception/ex/ErrorCode.java
+++ b/src/main/java/com/study/studyproject/global/exception/ex/ErrorCode.java
@@ -7,23 +7,29 @@ import static org.springframework.http.HttpStatus.*;
 
 @Getter
 public enum ErrorCode {
+    //로그인 및 회원가입
     MEMBER_DUPLICATED("이미 회원가입 하였습니다.", CONFLICT),
     NOT_FOUND_MEMBER("사용자를 찾지 못했습니다.", NOT_FOUND),
     NOT_FOUND_PASSWORD("비밀번호가 틀립니다.", CONFLICT),
-
     NICKNAME_DUPLICATED("이미 닉네임이 존재합니다. 다른 닉네임으로 변경해주세요.", CONFLICT),
 
 
+    //게시글
     NOT_FOUND_BOARD("게시글이 없습니다.", NOT_FOUND),
     UNABLE_DELETE_BOARD("게시글을 삭제 할 수 없습니다.", CONFLICT),
     NOT_FOUND_REPLY("댓글을 찾을 수 없습니다.", NOT_FOUND),
 
+    //관심글
     POST_LIKE_DUPLICATED("관심글이 이미 추가하였습니다.", BAD_REQUEST),
 
-    TOKEN_EXPIRED( "유효 기간이 만료된 토큰입니다.", FORBIDDEN),
-    UNABLE_ACCESS( "접근 권한이 없습니다.", UNAUTHORIZED),
+    //토큰
+    TOKEN_EXPIRED( "유효 기간이 만료된 토큰입니다.", UNAUTHORIZED),
+    UNABLE_ACCESS( "접근 권한이 없습니다.", FORBIDDEN),
+    EXPIRED_PERIOD_TOKEN("토큰이 만료되었습니다. 다시 로그인해주세요. ", UNAUTHORIZED ),
+    INVALID_REFRESH_TOKEN("올바르지 않은 형식의 RefreshToken입니다 다시 로그인해주세요. ", UNAUTHORIZED ),
 
 
+    //그 외 오류
     NOT_FOUND_PAGE("페이지가 없습니다.", NOT_FOUND ),
     INTERNAL_SEVER_ERROR("서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.", INTERNAL_SERVER_ERROR );
 

--- a/src/main/java/com/study/studyproject/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/study/studyproject/global/jwt/JwtAccessDeniedHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 @Component
 @Slf4j
 @RequiredArgsConstructor
+//403
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     private final ObjectMapper objectMapper; // For JSON serialization
 
@@ -27,11 +28,11 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
 
         ExceptionResponse errorResponse = ExceptionResponse.builder()
-                .message(ErrorCode.UNABLE_ACCESS.getMessage())
-                .status(ErrorCode.UNABLE_ACCESS.getStatus().value())
+                .message(ErrorCode.INVALID_REFRESH_TOKEN.getMessage())
+                .status(ErrorCode.INVALID_REFRESH_TOKEN.getStatus().value())
                 .build();
         // Set response properties
-        response.setStatus(ErrorCode.UNABLE_ACCESS.getStatus().value());
+        response.setStatus(ErrorCode.INVALID_REFRESH_TOKEN.getStatus().value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 

--- a/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
+++ b/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
@@ -2,6 +2,8 @@ package com.study.studyproject.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.studyproject.global.GlobalResultDto;
+import com.study.studyproject.global.exception.ex.ErrorCode;
+import com.study.studyproject.global.exception.ex.TokenNotValidationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,10 +14,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.study.studyproject.global.exception.ex.ErrorCode.TOKEN_EXPIRED;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,36 +34,26 @@ public class JwtFilter extends OncePerRequestFilter {
         log.info("로그인");
 
         String accessToken = jwtUtil.getHeaderToken(request, JwtUtil.ACCESS_TOKEN);
-        String refreshToken = jwtUtil.getHeaderToken(request, JwtUtil.REFRESH_TOKEN);
-        accessToken = resolveToken(accessToken);
-        refreshToken = resolveToken(refreshToken);
+        log.info("accessToken : {}", accessToken);
+
+        accessToken = jwtUtil.resolveToken(accessToken);
         if (accessToken == null) {
             setAuthentication(null);
         }
 
-        if (accessToken != null) {
-            if (jwtUtil.tokenValidation(accessToken)) {
+
+        if (accessToken != null) {//  회원일 경우,
+            if (jwtUtil.AccessTokenValidation(accessToken)) { // AccessToken 사용 가능
                 String emailFromToken = jwtUtil.getEmailFromToken(accessToken);
                 setAuthentication(emailFromToken);
-            } else if (refreshToken != null) {
-                Boolean isRefreshToken = jwtUtil.refreshTokenValidation(refreshToken);
-                if (isRefreshToken) {
-                    String emailFromToken = jwtUtil.getEmailFromToken(refreshToken);
-                    Long idFromToken = jwtUtil.getIdFromToken(refreshToken);
-
-                    String newAccessToken = jwtUtil.createToken(emailFromToken,idFromToken,jwtUtil.ACCESS_TOKEN);
-                    jwtUtil.setHeaderAccessToken(response, newAccessToken);
-                    setAuthentication(jwtUtil.getEmailFromToken(newAccessToken));
-                } else {
-                    jwtExceptionHandler(response, "만료된 JWT 서명입니다. IllegalArgumentException.", HttpStatus.BAD_REQUEST);
-                    return;
-                }
+            } else {
+                jwtExceptionHandler(response, ErrorCode.TOKEN_EXPIRED.getMessage(), HttpStatus.UNAUTHORIZED);
+                log.error("JWTFilter에서 만료");
+                return;
             }
         }
-
-
-
         filterChain.doFilter(request, response);
+
 
 
     }
@@ -69,21 +62,11 @@ public class JwtFilter extends OncePerRequestFilter {
         response.setStatus(statusCode.value());
         response.setContentType("application/json; charset=UTF-8");
         try {
-            String json = new ObjectMapper().writeValueAsString(new GlobalResultDto(message,statusCode.value()));
+            String json = new ObjectMapper().writeValueAsString(new GlobalResultDto(message, statusCode.value()));
             response.getWriter().write(json);
         } catch (Exception e) {
             log.error(e.getMessage());
         }
-    }
-
-    private  String resolveToken(String token) {
-
-        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
-            String[] split = token.split(" ");
-            return split[1];
-        }
-
-        return null;
     }
 
 

--- a/src/main/java/com/study/studyproject/login/controller/LoginController.java
+++ b/src/main/java/com/study/studyproject/login/controller/LoginController.java
@@ -1,8 +1,7 @@
 package com.study.studyproject.login.controller;
 
 import com.study.studyproject.global.GlobalResultDto;
-import com.study.studyproject.global.auth.UserDetailsImpl;
-import com.study.studyproject.global.jwt.JwtUtil;
+import com.study.studyproject.login.dto.AccessTokenResponse;
 import com.study.studyproject.login.dto.LoginRequest;
 import com.study.studyproject.login.dto.LoginResponseDto;
 import com.study.studyproject.login.dto.SignRequest;
@@ -14,24 +13,22 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
+import java.net.http.HttpResponse;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "로그인/로그아웃/회원가입 기능",description = "사용자의 로그인과 로그아웃 회원가입 기능")
+@Tag(name = "로그인/로그아웃/회원가입 기능", description = "사용자의 로그인과 로그아웃 회원가입 기능")
 @Slf4j
 public class LoginController {
 
     private final LoginService loginService;
     private final LogoutService logoutService;
-    private final JwtUtil jwtUtil;
 
     //회원가입
     @Operation(summary = "회원가입", description = "사용자 회원가입")
@@ -54,5 +51,20 @@ public class LoginController {
     public ResponseEntity<GlobalResultDto> logout(@RequestHeader("Access_Token") String token) {
         return ResponseEntity.ok(logoutService.logoutService(token));
     }
+
+
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급")
+    @PostMapping("/renew_token")
+    public ResponseEntity<AccessTokenResponse> renewAccessToken(
+            @RequestHeader("Access_Token") String access_token,
+            @RequestHeader("Refresh_Token") String refresh_token,
+            HttpServletResponse response
+    ) {
+
+        String renewAccessToken = loginService.renewalAccessToken(access_token, refresh_token, response);
+        return ResponseEntity.status(CREATED).body(new AccessTokenResponse(renewAccessToken));
+
+    }
+
 
 }

--- a/src/main/java/com/study/studyproject/login/domain/RefreshToken.java
+++ b/src/main/java/com/study/studyproject/login/domain/RefreshToken.java
@@ -43,4 +43,9 @@ public class RefreshToken {
         return this;
     }
 
+    public RefreshToken updateAccessToken(String token) {
+        this.accessToken= token;
+        return this;
+    }
+
 }

--- a/src/main/java/com/study/studyproject/login/dto/AccessTokenResponse.java
+++ b/src/main/java/com/study/studyproject/login/dto/AccessTokenResponse.java
@@ -1,0 +1,16 @@
+
+package com.study.studyproject.login.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
+public class AccessTokenResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/study/studyproject/login/service/LoginService.java
+++ b/src/main/java/com/study/studyproject/login/service/LoginService.java
@@ -1,6 +1,7 @@
 package com.study.studyproject.login.service;
 
 import com.study.studyproject.global.exception.ex.DuplicateException;
+import com.study.studyproject.global.exception.ex.TokenNotValidationException;
 import com.study.studyproject.member.domain.Member;
 import com.study.studyproject.login.domain.RefreshToken;
 import com.study.studyproject.global.GlobalResultDto;
@@ -21,8 +22,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 import static com.study.studyproject.global.exception.ex.ErrorCode.*;
 
 @Service
@@ -35,7 +34,7 @@ public class LoginService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
-
+    public static final String ACCESS_TOKEN = "Access_Token";
 
 
     public LoginResponseDto loginService(@Valid LoginRequest loginRequest, HttpServletResponse response) throws NotFoundException {
@@ -46,24 +45,23 @@ public class LoginService {
             throw new NotFoundException(NOT_FOUND_PASSWORD);
         }
 
-        TokenDtoResponse tokensDto = jwtUtil.createAllToken(loginRequest.getEmail(),member.getId());
-        Optional<RefreshToken> refreshToken = refreshRepository.findByAccessToken(tokensDto.getAccessToken());
-        if (refreshToken.isPresent()) {
-            refreshRepository.save(refreshToken.get().updateToken(tokensDto.getRefreshToken()));
-        } else {
-            RefreshToken getRefreshToken = RefreshToken.toEntity(tokensDto, loginRequest);
-            refreshRepository.save(getRefreshToken);
-        }
+        TokenDtoResponse tokensDto = jwtUtil.createAllToken(loginRequest.getEmail(), member.getId());
+        refreshRepository.findByAccessToken(tokensDto.getAccessToken())
+                .ifPresentOrElse(
+                        token -> refreshRepository.save(token.updateToken(tokensDto.getRefreshToken())), // 존재한다면
+                        () -> refreshRepository.save(RefreshToken.toEntity(tokensDto, loginRequest)) //존재하지 않으면
+                );
+
 
         setHeader(response, tokensDto);
 
-        return new LoginResponseDto("로그인 되었습니다.", HttpStatus.OK.value(),member.getNickname());
+        return new LoginResponseDto("로그인 되었습니다.", HttpStatus.OK.value(), member.getNickname());
 
     }
-    private void setHeader(HttpServletResponse response, TokenDtoResponse tokensDto) {
-        response.addHeader(JwtUtil.ACCESS_TOKEN, JwtUtil.BEARER+tokensDto.getAccessToken());
-        response.addHeader(JwtUtil.REFRESH_TOKEN, JwtUtil.BEARER+tokensDto.getRefreshToken());
 
+    private void setHeader(HttpServletResponse response, TokenDtoResponse tokensDto) {
+        response.addHeader(JwtUtil.ACCESS_TOKEN, JwtUtil.BEARER + tokensDto.getAccessToken());
+        response.addHeader(JwtUtil.REFRESH_TOKEN, JwtUtil.BEARER + tokensDto.getRefreshToken());
     }
 
 
@@ -73,7 +71,7 @@ public class LoginService {
         String encodePwd = passwordEncoder.encode(signRequest.getPwd());
         Member member = Member.toEntity(signRequest, encodePwd);
         memberRepository.save(member);
-        return new GlobalResultDto("회원가입 성공",HttpStatus.OK.value());
+        return new GlobalResultDto("회원가입 성공", HttpStatus.OK.value());
 
     }
 
@@ -90,4 +88,38 @@ public class LoginService {
     private boolean isPresentEmail(SignRequest signRequest) {
         return memberRepository.findByEmail(signRequest.getEmail()).isPresent();
     }
+
+    //토큰 엑세스 토큰 재발급
+    public String renewalAccessToken(String accessTokenRequest, String refreshTokenRequest, HttpServletResponse response ) {
+        String accessToken = jwtUtil.resolveToken(accessTokenRequest);
+        String refreshToken = jwtUtil.resolveToken(refreshTokenRequest);
+
+        // 기존 AT와 RT일치하는지 확인
+        if (jwtUtil.isValidRefreshAndInValidAccess(accessToken, refreshToken)) { //accessToken에 문제가 있는경우
+            log.info("AccessToken 재발급 문제 ");
+
+            String emailFromToken = jwtUtil.getEmailFromToken(refreshToken);
+            Long idFromToken = jwtUtil.getIdFromToken(refreshToken);
+
+            //재발급
+            RefreshToken getRefreshToken = refreshRepository.findById(emailFromToken).orElseThrow(() -> new TokenNotValidationException(INVALID_REFRESH_TOKEN));
+            String renewAccessToken = jwtUtil.createToken(emailFromToken, idFromToken, ACCESS_TOKEN); //엑세스 토큰 재생성
+            getRefreshToken.updateAccessToken(renewAccessToken); // 갱신
+            return renewAccessToken;
+
+        }
+
+        //AT 문제가 둘다 없는 경우
+        if (jwtUtil.isValidRefreshAndValidAccess(accessToken, refreshToken)) {
+            log.info("둘다 문제 없는 경우");
+            return accessToken;
+        }
+
+
+        //일치하지 않다면, 401
+        throw new TokenNotValidationException(EXPIRED_PERIOD_TOKEN);
+
+    }
+
+
 }

--- a/src/test/java/com/study/studyproject/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/study/studyproject/board/controller/BoardControllerTest.java
@@ -159,6 +159,7 @@ class BoardControllerTest  {
                 .andDo(print());
     }
 
+
     @Test
     @DisplayName("모집구분 변경한다.")
     void changeRecruitTest() throws Exception {
@@ -212,10 +213,6 @@ class BoardControllerTest  {
         Board board = createBoard(member1, "제목1", "내용1", "닉네임1", CS);
         memberRepository.save(member1);
         boardRepository.save(board);
-        TokenDtoResponse allToken = jwtUtil.createAllToken(member1.getEmail(), member1.getId());
-        System.out.println("allToken.getAccessToken() = " + allToken.getAccessToken());
-        System.out.println("allToken.getAccessToken() = " + allToken.getRefreshToken());
-
         //when then
         mockMvc.perform(get("/board/"+board.getId())
                         .param("boardId", String.valueOf(board.getId()))

--- a/src/test/java/com/study/studyproject/list/controller/MainControllerTest.java
+++ b/src/test/java/com/study/studyproject/list/controller/MainControllerTest.java
@@ -1,10 +1,15 @@
 package com.study.studyproject.list.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.studyproject.board.domain.ConnectionType;
+import com.study.studyproject.board.domain.OfflineLocation;
 import com.study.studyproject.board.repository.BoardRepository;
 import com.study.studyproject.board.domain.Board;
 import com.study.studyproject.board.domain.Category;
+import com.study.studyproject.list.dto.MainRequestDto;
 import com.study.studyproject.member.domain.Member;
 import com.study.studyproject.member.repository.MemberRepository;
+import com.study.studyproject.reply.dto.ReplyRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,9 +19,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.study.studyproject.board.domain.Category.*;
 import static com.study.studyproject.board.domain.Category.코테;
+import static com.study.studyproject.board.domain.ConnectionType.OFFLINE;
+import static com.study.studyproject.board.domain.ConnectionType.ONLINE;
 import static com.study.studyproject.login.domain.Role.ROLE_USER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -35,6 +43,8 @@ class MainControllerTest {
 
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
 
 
     @Test
@@ -42,9 +52,9 @@ class MainControllerTest {
     void mainListAllTestCreateDateDesc() throws Exception {
         //given
         Member member1 = createMember("jacom2@naver.com", "!12341234", "사용자명1", "닉네임0");
-        Board board = createBoard(member1, "제목1", "내용1", "닉네임1", CS);
-        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS);
-        Board board2 = createBoard(member1, "제목3", "내용3", "닉네임3", 기타);
+        Board board = createBoard(member1, "제목1", "내용1", "닉네임1", CS,ONLINE);
+        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS,ONLINE);
+        Board board2 = createBoard(member1, "제목3", "내용3", "닉네임3", 기타,ONLINE);
 
         memberRepository.save(member1);
         boardRepository.save(board);
@@ -64,9 +74,9 @@ class MainControllerTest {
     void mainListAllTestAsc() throws Exception {
         //given
         Member member1 = createMember("jacom2@naver.com", "!12341234", "사용자명1", "닉네임0");
-        Board board = createBoard(member1, "제목1", "내용1", "닉네임1", CS);
-        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS);
-        Board board2 = createBoard(member1, "제목3", "내용3", "닉네임3", 기타);
+        Board board = createBoard(member1, "제목1", "내용1", "닉네임1", CS,ONLINE);
+        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS,ONLINE);
+        Board board2 = createBoard(member1, "제목3", "내용3", "닉네임3", 기타,OFFLINE);
 
         memberRepository.saveAll(List.of(member1));
         boardRepository.save(board);
@@ -75,11 +85,8 @@ class MainControllerTest {
 
         board1.updateViewCnt();
 
-
         //when & then
         mockMvc.perform(get("/")
-                        .param("order","1")
-
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -94,11 +101,11 @@ class MainControllerTest {
     void mainListAlltarget() throws Exception {
         //given
         Member member1 = createMember("jacom2@naver.com", "!12341234", "사용자명1", "닉네임0");
-        Board board0 = createBoard(member1, "제목1", "내용1", "닉네임1", CS);
-        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS);
-        Board board2 = createBoard(member1, "자바공부 풀 사람1", "내용3", "닉네임3", 기타);
-        Board board3 = createBoard(member1, "제목15", "내용3", "닉네임3", 코테);
-        Board board4 = createBoard(member1, "타이틀1", "내용3", "닉네임3", 코테);
+        Board board0 = createBoard(member1, "제목1", "내용1", "닉네임1", CS, ONLINE);
+        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS,ONLINE);
+        Board board2 = createBoard(member1, "자바공부 풀 사람1", "내용3", "닉네임3", 기타,ONLINE);
+        Board board3 = createBoard(member1, "제목15", "내용3", "닉네임3", 코테,ONLINE);
+        Board board4 = createBoard(member1, "타이틀1", "내용3", "닉네임3", 코테,ONLINE);
 
         memberRepository.save((member1));
         List<Board> products = List.of(board0, board1, board2,board3,board4);
@@ -121,15 +128,15 @@ class MainControllerTest {
 
 
     @Test
-    @DisplayName("CS 카테고리의 게시글만 최신순으로 조회한다.")
+    @DisplayName("오프라인과  CS 카테고리의 게시글만 최신순으로 조회한다.")
     void mainListAllWithCS() throws Exception {
         //given
         Member member1 = createMember("jacom2@naver.com", "!12341234", "사용자명1", "닉네임0");
-        Board board0 = createBoard(member1, "제목1", "내용1", "닉네임1", CS);
-        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS);
-        Board board2 = createBoard(member1, "자바공부 풀 사람1", "내용3", "닉네임3", 기타);
-        Board board3 = createBoard(member1, "제목15", "내용3", "닉네임3", 코테);
-        Board board4 = createBoard(member1, "타이틀1", "내용3", "닉네임3", 코테);
+        Board board0 = createBoard(member1, "제목1", "내용1", "닉네임1", CS,ONLINE);
+        Board board1 = createBoard(member1, "제목2", "내용2", "닉네임2", CS,ONLINE);
+        Board board2 = createBoard(member1, "자바공부 풀 사람1", "내용3", "닉네임3", 기타,OFFLINE);
+        Board board3 = createBoard(member1, "제목15", "내용3", "닉네임3", CS,OFFLINE);
+        Board board4 = createBoard(member1, "타이틀1", "내용3", "닉네임3", 코테,OFFLINE);
 
         memberRepository.save((member1));
         boardRepository.save(board0);
@@ -139,18 +146,18 @@ class MainControllerTest {
         List<Board> boards = boardRepository.saveAll(products);
 
 
-
-
         //when & then
         mockMvc.perform(get("/")
                         .param("Category", "CS")
+                        .param("connectionType", "OFFLINE")
+
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].title").value("제목1"))
+                .andExpect(jsonPath("$.content[0].title").value("제목15"))
                 .andExpect(jsonPath("$.content[0].type").value("CS"))
-                .andExpect(jsonPath("$.content[1].title").value("제목2"))
-                .andExpect(jsonPath("$.content[1].type").value("CS"));
+                .andExpect(jsonPath("$.totalPages").value("1"));
+
 
     }
 
@@ -169,13 +176,14 @@ class MainControllerTest {
     }
 
     private Board createBoard(
-            Member member, String title, String content, String nickname, Category category
+            Member member, String title, String content, String nickname, Category category, ConnectionType connectionType
     ) {
         return Board.builder()
                 .member(member)
                 .title(title)
                 .content("내용")
                 .category(category)
+                .connectionType(connectionType)
                 .build();
     }
 

--- a/src/test/java/com/study/studyproject/login/service/LoginServiceTest.java
+++ b/src/test/java/com/study/studyproject/login/service/LoginServiceTest.java
@@ -1,5 +1,6 @@
 package com.study.studyproject.login.service;
 
+import com.study.studyproject.global.exception.ex.DuplicateException;
 import com.study.studyproject.member.domain.Member;
 import com.study.studyproject.global.exception.ex.NotFoundException;
 import com.study.studyproject.login.dto.LoginRequest;
@@ -120,7 +121,7 @@ class LoginServiceTest {
 
         //when & then
         assertThatThrownBy(() -> loginService.sign(signRequest))
-                .isInstanceOf(NotFoundException.class);
+                .isInstanceOf(DuplicateException.class);
 
     }
     

--- a/src/test/java/com/study/studyproject/reply/controller/ReplyControllerTest.java
+++ b/src/test/java/com/study/studyproject/reply/controller/ReplyControllerTest.java
@@ -102,7 +102,9 @@ class ReplyControllerTest {
 
                 )
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.boardId").value("게시글 번호를 입력해주세요."))
+                .andExpect(jsonPath("$.content").value("댓글 내용을 입력해주세요"));
 
     }
 


### PR DESCRIPTION
## 개요
- closed : #79 
- 문제 : 토큰이 만료되었지만, 예외가 발생하지 않는 문제 발생

## 작업사항
- 엑세스 토큰 로직 변경


## 변경로직(optional)
-  로그인 시 AT1/RT1 발급, DB(RDB,Redis) 저장 후 body에 담아 응답
- 인증 필요 API 호출 시 토큰 필터 경유
    - Authorization 헤더의 Bearer 값 파싱
     -    존재하지 않을 경우 / 401
    - 토큰 만료 예외 발생 시 401
     - 기타 파싱 예와 (malform, Invalid signature..) 401
- 파싱 성공 및 보안 객체 생성 완료했으나 authority가 만족되지 않아 AccessDeniedHandler 탈경우 403

- 토큰 재발급 요청 수신 시 DB에 저장된 토큰 쌍(AT1/RT1을 가져옴)
- header를 통해 AT1/RT1과 일치하는지 확인
- 일치한다면 AT2/RT2 재발급 (RT2의 exp는 RT1과 동일), 재발급된 토큰 쌍을 DB에 저장 및 반환
- rotation 방식 채택 이유 : RT가 유출되더라도 원유저가 토큰 재발급 시 유출된 RT는 유효하지 않기 때문
- 일치하지 않는다면 401 떨굼

클라측 : /token/refresh 요청 시 응답이 401이라면 로그아웃 처리 (클라이언트 별 로컬 저장소의 토큰 말소 )


