### PR TITLE
Refactor/#87 게시글 상세 페이지 SRP 준수

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -9,9 +9,9 @@ name: Spring Boot & Gradle CI/CD
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
   push:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/src/main/java/com/study/studyproject/board/controller/BoardController.java
+++ b/src/main/java/com/study/studyproject/board/controller/BoardController.java
@@ -31,21 +31,21 @@ public class BoardController {
     //글쓰기 수정
     @PatchMapping("member")
     @Operation(summary = "글쓰기 수정", description = "글쓰기 수정 기능")
-    public ResponseEntity<GlobalResultDto> updateWriting(@RequestBody @Validated  BoardReUpdateRequestDto boardReUpdateRequestDto) {
+    public ResponseEntity<GlobalResultDto> updateWriting(@RequestBody @Validated BoardReUpdateRequestDto boardReUpdateRequestDto) {
         return ResponseEntity.ok(boardService.updateWrite(boardReUpdateRequestDto));
 
     }
 
     @PostMapping("member")
     @Operation(summary = "글쓰기 작성", description = "글쓰기 작성")
-    public ResponseEntity<GlobalResultDto> writing(@RequestBody @Validated  BoardWriteRequestDto boardWriteRequestDto,@Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails)  {
-        return ResponseEntity.ok(boardService.boardSave(boardWriteRequestDto,userDetails.getMemberId()));
+    public ResponseEntity<GlobalResultDto> writing(@RequestBody @Validated BoardWriteRequestDto boardWriteRequestDto, @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(boardService.boardSave(boardWriteRequestDto, userDetails.getMemberId()));
 
     }
 
     @Operation(summary = "모집구분 변경", description = "모집구분 변경")
     @PatchMapping("/member/recruit/{boardId}")
-    public ResponseEntity<GlobalResultDto> changeRecruit(@PathVariable(name = "boardId") Long boardId ) {
+    public ResponseEntity<GlobalResultDto> changeRecruit(@PathVariable(name = "boardId") Long boardId) {
         return ResponseEntity.ok(boardService.changeRecruit(boardId));
     }
 
@@ -53,25 +53,24 @@ public class BoardController {
     //삭제
     @DeleteMapping("member/{boardId}")
     @Operation(summary = "게시글 삭제 ", description = "해당 게시글 삭제")
-    public ResponseEntity<GlobalResultDto> deleteBoard(@PathVariable(name = "boardId",required = true) Long boardId) {
-        return ResponseEntity.ok(boardService.boardDeleteOne(boardId,null));
+    public ResponseEntity<GlobalResultDto> deleteBoard(@PathVariable(name = "boardId", required = true) Long boardId) {
+        return ResponseEntity.ok(boardService.boardDeleteOne(boardId, null));
     }
 
 
     //글 조회 1개 -
     @GetMapping("/{boardId}")
     @Operation(summary = "게시글 상세", description = "게시글 상세페이지")
-    public ResponseEntity<BoardOneResponseDto> getBoard(@Parameter(description = "게시판 ID") @PathVariable(name = "boardId") Long boardId,	@Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails
-,HttpServletRequest request,
-    HttpServletResponse response
+    public ResponseEntity<BoardOneResponseDto> getBoard(@Parameter(description = "게시판 ID") @PathVariable(name = "boardId") Long boardId,
+                                                        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails
+            , HttpServletRequest request,HttpServletResponse response
 
     ) {
-        boardService.updateView(boardId,  request,  response);
-        BoardOneResponseDto boardOneResponseDto = boardService.boardOne(boardId,userDetails);
+        boardService.updateView(boardId, request, response);
+        BoardOneResponseDto boardOneResponseDto = boardService.boardOne(boardId, userDetails);
         return ResponseEntity.ok(boardOneResponseDto);
 
     }
-
 
 
 }

--- a/src/main/java/com/study/studyproject/board/domain/Board.java
+++ b/src/main/java/com/study/studyproject/board/domain/Board.java
@@ -2,6 +2,7 @@ package com.study.studyproject.board.domain;
 
 import com.study.studyproject.board.dto.BoardReUpdateRequestDto;
 import com.study.studyproject.global.config.BaseTimeEntity;
+import com.study.studyproject.global.exception.ex.NotFoundException;
 import com.study.studyproject.member.domain.Member;
 import com.study.studyproject.postlike.domain.PostLike;
 import com.study.studyproject.reply.domain.Reply;
@@ -15,6 +16,9 @@ import org.hibernate.annotations.ColumnDefault;
 import java.util.List;
 
 import static com.study.studyproject.board.domain.Recruit.*;
+import static com.study.studyproject.global.exception.ex.ErrorCode.UNABLE_DELETE_BOARD;
+import static com.study.studyproject.postlike.domain.PostLike.isPostLikes;
+import static com.study.studyproject.reply.domain.Reply.isReplies;
 
 @Getter
 @Entity
@@ -116,6 +120,11 @@ public class Board extends BaseTimeEntity {
     }
 
 
+    public static void validateDeleteBoard(List<Reply> replies, List<PostLike> postLikes) throws NotFoundException {
+        if (isReplies(replies) || isPostLikes(postLikes)) {
+            throw new NotFoundException(UNABLE_DELETE_BOARD);
+        }
+    }
 
 
 

--- a/src/main/java/com/study/studyproject/board/dto/BoardOneResponseDto.java
+++ b/src/main/java/com/study/studyproject/board/dto/BoardOneResponseDto.java
@@ -2,7 +2,7 @@ package com.study.studyproject.board.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.study.studyproject.board.domain.*;
-import com.study.studyproject.reply.dto.ReplyResponseDto;
+import com.study.studyproject.postlike.dto.PostLikeOneResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,6 +17,7 @@ public class BoardOneResponseDto {
 
     Recruit recruit;
     @Schema(description = "현재 닉네임", defaultValue = "jacom!!")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     String currentNickname;
 
     @Schema(description = "제목", defaultValue = "제목제목")
@@ -40,24 +41,14 @@ public class BoardOneResponseDto {
     @Schema(description = "조회수", defaultValue = "3")
     int viewCnt;
 
-    @Schema(description = "관심글", defaultValue = "관심중")
-    String postLike;
-
-    @Schema(description = "관심글ID", defaultValue = "2")
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    Long postLikeId;
-
-
-    @Schema(description = "댓글")
-    ReplyResponseDto replyResponseDto;
-
     @Schema(description = "타입", defaultValue = "오프라인")
     ConnectionType connectionType;
 
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     OfflineLocation offlineLocation;
 
     @Builder
-    public BoardOneResponseDto(Recruit recruit, String currentNickname, String title, String boardWriteNickname, LocalDateTime updateTime, LocalDateTime createTime, String content, Category category, int viewCnt, String postLike, Long postLikeId, ReplyResponseDto replyResponseDto, ConnectionType type, OfflineLocation offlineLocation) {
+    public BoardOneResponseDto(Recruit recruit, String currentNickname, String title, String boardWriteNickname, LocalDateTime updateTime, LocalDateTime createTime, String content, Category category, int viewCnt,ConnectionType type, OfflineLocation offlineLocation) {
         this.recruit = recruit;
         this.currentNickname = currentNickname;
         this.title = title;
@@ -67,33 +58,27 @@ public class BoardOneResponseDto {
         this.content = content;
         this.category = category;
         this.viewCnt = viewCnt;
-        this.postLike = postLike;
-        this.postLikeId = postLikeId;
-        this.replyResponseDto = replyResponseDto;
         this.connectionType = type;
         this.offlineLocation = offlineLocation;
     }
 
 
 
-    public static BoardOneResponseDto of(Long postLikeId, String postLike, Board board, ReplyResponseDto replies, String nickname) {
+    public static BoardOneResponseDto of(Board board, String nickname) {
 
-        String nickname1 = board.getMember().getNickname();
+        String boardNickname = board.getMember().getNickname();
         return BoardOneResponseDto.builder()
                 .updateTime(board.getLastModifiedDate())
                 .createTime(board.getCreatedDate())
                 .title(board.getTitle())
                 .recruit(board.getRecruit())
                 .content(board.getContent())
-                .postLike(postLike)
-                .postLikeId(postLikeId)
                 .viewCnt(Math.toIntExact(board.getViewCount()))
-                .boardWriteNickname(nickname1)
+                .boardWriteNickname(boardNickname)
                 .currentNickname(nickname)
                 .type(board.getConnectionType())
                 .offlineLocation(board.getOfflineLocation())
                 .category(board.getCategory())
-                .replyResponseDto(replies)
                 .build();
     }
     

--- a/src/main/java/com/study/studyproject/board/repository/BoardRepository.java
+++ b/src/main/java/com/study/studyproject/board/repository/BoardRepository.java
@@ -2,10 +2,12 @@ package com.study.studyproject.board.repository;
 
 import com.study.studyproject.board.domain.Board;
 import jakarta.persistence.LockModeType;
+import org.hibernate.annotations.PartitionKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,7 +15,7 @@ public interface BoardRepository extends JpaRepository<Board, Long>  {
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Board b SET b.viewCount = b.viewCount + 1 WHERE b.id = :id")
-    int updateHits(Long id);
+    int updateHits(@Param("id") Long id);
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT b FROM Board b WHERE b.id = :id")
     Optional<Board> findByIdForUpdate(Long id);

--- a/src/main/java/com/study/studyproject/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/study/studyproject/board/service/BoardServiceImpl.java
@@ -12,11 +12,10 @@ import com.study.studyproject.login.domain.Role;
 import com.study.studyproject.member.domain.Member;
 import com.study.studyproject.member.repository.MemberRepository;
 import com.study.studyproject.postlike.domain.PostLike;
-import com.study.studyproject.postlike.domain.PostLikeState;
+import com.study.studyproject.postlike.dto.PostLikeOneResponseDto;
 import com.study.studyproject.postlike.repository.PostLikeRepository;
+import com.study.studyproject.postlike.service.PostLikeService;
 import com.study.studyproject.reply.domain.Reply;
-import com.study.studyproject.reply.dto.ReplyInfoResponseDto;
-import com.study.studyproject.reply.dto.ReplyResponseDto;
 import com.study.studyproject.reply.repository.ReplyRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,10 +30,10 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
+import static com.study.studyproject.board.domain.Board.validateDeleteBoard;
 import static com.study.studyproject.global.exception.ex.ErrorCode.NOT_FOUND_BOARD;
-import static com.study.studyproject.global.exception.ex.ErrorCode.UNABLE_DELETE_BOARD;
-import static com.study.studyproject.reply.dto.ReplyInfoResponseDto.convertReplyToDto;
-import static com.study.studyproject.reply.dto.ReplyResponseDto.ReplyResponseToDto;
+import static com.study.studyproject.login.domain.Role.isAdmin;
+import static com.study.studyproject.login.domain.Role.isAnonymous;
 
 @Transactional
 @RequiredArgsConstructor
@@ -51,17 +50,21 @@ public class BoardServiceImpl implements BoardService {
     //작성
     @Override
     public GlobalResultDto boardSave(BoardWriteRequestDto boardWriteRequestDto, Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+        Member member = findMemberById(memberId);
         Board entity = boardWriteRequestDto.toEntity(member);
         boardRepository.save(entity);
         return new GlobalResultDto("글 작성 완료", HttpStatus.OK.value());
 
     }
 
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+    }
+
     //수정
     @Override
     public GlobalResultDto updateWrite(BoardReUpdateRequestDto boardReUpdateRequestDto) {
-        Board board = boardRepository.findById(boardReUpdateRequestDto.getBoardId()).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+        Board board = findBoardById(boardReUpdateRequestDto.getBoardId());
         board.updateBoard(boardReUpdateRequestDto);
         return new GlobalResultDto("글 작성 완료", HttpStatus.OK.value());
     }
@@ -70,102 +73,72 @@ public class BoardServiceImpl implements BoardService {
     //글 1개만 가져오기
     @Override
     public BoardOneResponseDto boardOne(Long boardId, UserDetailsImpl userDetails) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
-        String postLike = getPostLike(userDetails, board);
-        Long postLikeId = getPostLikeId(userDetails, board);
-        ReplyResponseDto replies = findReplies(boardId);
-        return BoardOneResponseDto.of(postLikeId,postLike, board, replies,userDetails.getNickname());
-    }
-
-    private Long getPostLikeId(UserDetailsImpl userDetails, Board board) {
-        Optional<PostLike> findByPostLike = postLikeRepository.findByBoardAndMember(board, userDetails.getMember());
-        if (findByPostLike.isPresent()) {
-            return findByPostLike.get().getId();
+        Board board = findBoardById(boardId);
+        if (isAnonymous()) {
+            return BoardOneResponseDto.of(board, null);
         }
-        return 0L;
+        return BoardOneResponseDto.of(board, userDetails.getNickname());
 
     }
+
+
+    private Board findBoardById(Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+    }
+
+
 
     @Transactional
     public void updateView(Long boardId,HttpServletRequest request, HttpServletResponse response){
-        if (!boardRepository.existsById(boardId)) {
-            throw new NotFoundException(NOT_FOUND_BOARD);
-        }
-        if(!checkCookie(boardId, request)){
+        validateBoardExists(boardId);
+        if(isNewView(boardId, request)){
             Cookie newCookie = createCookieForForNotOverlap(boardId);
             response.addCookie(newCookie);
             boardRepository.updateHits(boardId);
         }
     }
 
-    private boolean checkCookie(Long boardId, HttpServletRequest request) {
+    private void validateBoardExists(Long boardId) {
+        if (boardRepository.existsById(boardId)) {
+            return;
+        }
+        throw new NotFoundException(NOT_FOUND_BOARD);
+    }
+
+    private boolean isNewView(Long boardId, HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals(VIEWCOOKIENAME + boardId)) {
-                    return true;  // 이미 조회한 경우
+                    return false;  // 이미 조회한 경우
                 }
             }
         }
-        return false;  // 조회하지 않은 경우
+        return true;  // 조회하지 않은 경우
 
     }
 
     private Cookie createCookieForForNotOverlap(Long postId) {
         Cookie cookie = new Cookie(VIEWCOOKIENAME + postId, String.valueOf(postId));
-        cookie.setMaxAge(getRemainSecondForTommorow());
+        cookie.setMaxAge(getRemainSecondForTomorrow());
         cookie.setHttpOnly(true);
         return cookie;
     }
 
-    private int getRemainSecondForTommorow() {
+    private int getRemainSecondForTomorrow() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime tommorow = LocalDateTime.now().plusDays(1L).truncatedTo(ChronoUnit.DAYS);
         return (int) now.until(tommorow, ChronoUnit.SECONDS);
     }
 
 
-    private String getPostLike(UserDetailsImpl userDetails, Board board) {
-        if (Role.containsLoginRoleType(userDetails.getAuthority())) {
-            Optional<PostLike> byBoardAndMember = postLikeRepository.findByBoardAndMember(board, userDetails.getMember());
-            return byBoardAndMember.isPresent() ? PostLikeState.LIKING.getName() : PostLikeState.LIKE.getName();
-        }
-        return null;
-    }
-
-
-    private ReplyResponseDto findReplies(Long boardId) {
-        List<Reply> comments = replyRepository.findByBoardReply(boardId);
-        List<ReplyInfoResponseDto> commentResponseDTOList = getReplyInfoResponseDtos(comments);
-        return ReplyResponseToDto(comments.size(), commentResponseDTOList);
-    }
-
-    private static List<ReplyInfoResponseDto> getReplyInfoResponseDtos(List<Reply> comments) {
-
-       List<ReplyInfoResponseDto> commentResponseDTOList = new ArrayList<>();
-        Map<Long, ReplyInfoResponseDto> commentDTOHashMap = new HashMap<>();
-
-        comments.forEach(c -> {
-            ReplyInfoResponseDto commentResponseDTO = convertReplyToDto(c);
-            commentDTOHashMap.put(commentResponseDTO.getReplyId(), commentResponseDTO);
-            if (c.getParent() != null) // 자식일 경우
-                commentDTOHashMap.get(c.getParent().getId()).getChildren().add(commentResponseDTO);
-            else commentResponseDTOList.add(commentResponseDTO); // 부모일 경우
-        });
-
-        return commentResponseDTOList;
-    }
-
-
-    //삭제
     @Override
     public GlobalResultDto boardDeleteOne(Long boardId, Role role) {
         if (isAdmin(role)) {
-            Board board = boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+            Board board = findBoardById(boardId);
             board.changeAdminDeleteBoard();
             return new GlobalResultDto("관리자 권한으로 게시글 삭제 완료", HttpStatus.OK.value());
         }
-
 
         //댓글
         List<Reply> replies = replyRepository.findByBoardReplies(boardId);
@@ -179,32 +152,11 @@ public class BoardServiceImpl implements BoardService {
         return new GlobalResultDto("게시글 삭제 완료", HttpStatus.OK.value());
     }
 
-    private static void validateDeleteBoard(List<Reply> replies, List<PostLike> postLikes) throws NotFoundException {
-        if (isReplies(replies) || isPostLikes(postLikes)) {
-            throw new NotFoundException(UNABLE_DELETE_BOARD);
-        }
-    }
-
-
-
-
-
-    private static boolean isPostLikes(List<PostLike> postLikes) {
-        return postLikes.size() != 0;
-    }
-
-    private static boolean isReplies(List<Reply> replies) {
-        return replies.size() != 0;
-    }
-
-    private static boolean isAdmin(Role role) {
-        return role == Role.ROLE_ADMIN;
-    }
 
     //모집 구분 변경
     @Override
     public GlobalResultDto changeRecruit(Long boardId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+        Board board = findBoardById(boardId);
         board.changeRecuritBoard();
         return new GlobalResultDto("모집 구분 변경 완료", HttpStatus.OK.value());
     }

--- a/src/main/java/com/study/studyproject/global/auth/UserDetailsImpl.java
+++ b/src/main/java/com/study/studyproject/global/auth/UserDetailsImpl.java
@@ -37,11 +37,6 @@ public class UserDetailsImpl implements UserDetails, OAuth2User {
     }
 
 
-    public UserDetailsImpl guest() {
-        return new UserDetailsImpl(null,Role.ROLE_GUEST, 0L);
-    }
-
-    @Override
     public Map<String, Object> getAttributes() {
         return null;
     }
@@ -79,11 +74,6 @@ public class UserDetailsImpl implements UserDetails, OAuth2User {
 
     public String getEmail() {
         return member != null ? member.getEmail():null;
-    }
-
-
-    public boolean isGuest(){
-        return member == null;
     }
 
 

--- a/src/main/java/com/study/studyproject/global/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/study/studyproject/global/auth/UserDetailsServiceImpl.java
@@ -20,13 +20,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = null;
-        try {
-            member = memberRepository.findByEmail(email).orElseThrow(()->new NotFoundException(NOT_FOUND_MEMBER));
-        } catch (NotFoundException e) {
-            return new UserDetailsImpl(null, Role.ROLE_GUEST, 0L);
-        };
-
-        return new UserDetailsImpl(member,member.getRole(),member.getId());
+        return memberRepository.findByEmail(email)
+                .map(member -> new UserDetailsImpl(member, member.getRole(), member.getId()))
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
     }
 }

--- a/src/main/java/com/study/studyproject/global/exception/advice/ExControllerAdvice.java
+++ b/src/main/java/com/study/studyproject/global/exception/advice/ExControllerAdvice.java
@@ -59,8 +59,6 @@ public class ExControllerAdvice extends ResponseEntityExceptionHandler {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors()
                 .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
-        log.error("error :{}" ,errors);
-
         return ResponseEntity.status(status.value()).body(errors);
     }
 

--- a/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
+++ b/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.studyproject.global.GlobalResultDto;
 import com.study.studyproject.global.exception.ex.ErrorCode;
 import com.study.studyproject.global.exception.ex.TokenNotValidationException;
+import com.study.studyproject.login.domain.Role;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,22 +34,12 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("로그인");
 
-        String path = request.getRequestURI();
-        if (path.equals("/renew-token")) {
-            filterChain.doFilter(request, response); // 다음 필터로 이동
-            return;
-        }
-
         String accessToken = jwtUtil.getHeaderToken(request, JwtUtil.ACCESS_TOKEN);
-        log.info("accessToken : {}", accessToken);
 
         accessToken = jwtUtil.resolveToken(accessToken);
         if (accessToken == null) {
-            setAuthentication(null);
         }
-
-
-        if (accessToken != null) {//  회원일 경우,
+        if (accessToken != null ) {//  회원일 경우,
             if (jwtUtil.AccessTokenValidation(accessToken)) { // AccessToken 사용 가능
                 String emailFromToken = jwtUtil.getEmailFromToken(accessToken);
                 setAuthentication(emailFromToken);
@@ -57,7 +48,9 @@ public class JwtFilter extends OncePerRequestFilter {
                 return;
             }
         }
+
         filterChain.doFilter(request, response);
+
 
 
 

--- a/src/main/java/com/study/studyproject/global/jwt/JwtUtil.java
+++ b/src/main/java/com/study/studyproject/global/jwt/JwtUtil.java
@@ -91,9 +91,6 @@ public class JwtUtil {
     }
 
 
-
-
-
     // 토큰 생성
     public TokenDtoResponse createAllToken(String email, Long id) {
         String access = createToken(email, id, ACCESS_TOKEN);
@@ -148,8 +145,8 @@ public class JwtUtil {
 
     public boolean isValidRefreshAndInValidAccess(String accessToken, String refreshToken) {
         validateRefreshToken(refreshToken);
-        if(!AccessTokenValidation(accessToken)) return true;
-        return false;
+        if(AccessTokenValidation(accessToken)) return false;
+        return true;
     }
 
 

--- a/src/main/java/com/study/studyproject/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/study/studyproject/global/oauth/CustomOAuth2UserService.java
@@ -58,10 +58,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 
     private SocialType getSocialType(String registrationId) {
-        if (NAVER.name().equalsIgnoreCase(registrationId)) {
+        if ("NAVER".equals(registrationId)) {
             return NAVER;
         }
-        if (KAKAO.name().equalsIgnoreCase(registrationId)) {
+        if ("KAKAO".equals(registrationId)) {
             return KAKAO;
         }
 

--- a/src/main/java/com/study/studyproject/login/domain/Role.java
+++ b/src/main/java/com/study/studyproject/login/domain/Role.java
@@ -1,7 +1,11 @@
 package com.study.studyproject.login.domain;
 
+import com.study.studyproject.member.domain.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 
@@ -9,11 +13,28 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum Role {
     ROLE_USER,
-    ROLE_ADMIN
-    ,ROLE_GUEST;
+    ROLE_ADMIN;
 
     public static boolean containsLoginRoleType(Role type) {
         return List.of(ROLE_USER, ROLE_ADMIN).contains(type);
     }
+
+
+    public static boolean isAdmin(Role role) {
+        return role == Role.ROLE_ADMIN;
+    }
+
+    public static boolean isAnonymous() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+
 
 }

--- a/src/main/java/com/study/studyproject/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/study/studyproject/member/service/MemberServiceImpl.java
@@ -45,7 +45,6 @@ public class MemberServiceImpl implements MemberService{
 
         if (memberRepository.existsByNickname(memberUpdateResDto.getNickname())) {
             throw new DuplicateException(NICKNAME_DUPLICATED);
-
         }
 
 

--- a/src/main/java/com/study/studyproject/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/study/studyproject/postlike/controller/PostLikeController.java
@@ -3,16 +3,16 @@ package com.study.studyproject.postlike.controller;
 
 import com.study.studyproject.global.GlobalResultDto;
 import com.study.studyproject.global.auth.UserDetailsImpl;
-import com.study.studyproject.global.jwt.JwtUtil;
-import com.study.studyproject.member.dto.UserInfoResponseDto;
+import com.study.studyproject.login.domain.Role;
+import com.study.studyproject.postlike.dto.PostLikeOneResponseDto;
 import com.study.studyproject.postlike.service.PostLikeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -20,9 +20,21 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/post-like/")
 @Tag(name = "사용자 관심 글",description = "사용장 관심 글 기능 수정 및 삭제")
+@Slf4j
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
+
+    @Operation(summary = "관심 여부", description = "게시글 관심 조회")
+    @GetMapping("{boardId}")
+    public ResponseEntity<PostLikeOneResponseDto> postLikeView(@PathVariable("boardId") Long boardId, @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if(Role.isAnonymous()){
+            return null;
+        }
+        return ResponseEntity.ok(postLikeService.getPostLikeForOneBoard(userDetails.getMember(), boardId));
+
+    }
+
 
     @Operation(summary = "관심글 등록", description = "사용자의 관심글 등록합니다.")
     @PostMapping("{boardId}")

--- a/src/main/java/com/study/studyproject/postlike/domain/PostLike.java
+++ b/src/main/java/com/study/studyproject/postlike/domain/PostLike.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 import static jakarta.persistence.FetchType.LAZY;
 
 
@@ -42,6 +44,11 @@ public class PostLike extends BaseTimeEntity {
                 .board(board)
                 .build();
     }
+
+    public static boolean isPostLikes(List<PostLike> postLikes) {
+        return postLikes.size() != 0;
+    }
+
 
 
 

--- a/src/main/java/com/study/studyproject/postlike/dto/PostLikeOneResponseDto.java
+++ b/src/main/java/com/study/studyproject/postlike/dto/PostLikeOneResponseDto.java
@@ -1,0 +1,33 @@
+package com.study.studyproject.postlike.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.study.studyproject.board.dto.BoardOneResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostLikeOneResponseDto {
+
+
+    @Schema(description = "관심글", defaultValue = "관심중")
+    String postLike;
+
+    @Schema(description = "관심글ID", defaultValue = "2")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    Long postLikeId;
+
+
+    @Builder
+    public PostLikeOneResponseDto(String postLike, Long postLikeId) {
+        this.postLike = postLike;
+        this.postLikeId = postLikeId;
+    }
+
+    public static PostLikeOneResponseDto of(String postLike, Long postLikeId) {
+        return PostLikeOneResponseDto.builder()
+                .postLike(postLike)
+                .postLikeId(postLikeId)
+                .build();
+    }
+}

--- a/src/main/java/com/study/studyproject/postlike/service/PostLikeService.java
+++ b/src/main/java/com/study/studyproject/postlike/service/PostLikeService.java
@@ -8,7 +8,8 @@ import com.study.studyproject.postlike.domain.PostLike;
 import com.study.studyproject.global.GlobalResultDto;
 import com.study.studyproject.global.exception.ex.BadRequestException;
 import com.study.studyproject.global.exception.ex.NotFoundException;
-import com.study.studyproject.member.repository.MemberRepository;
+import com.study.studyproject.postlike.domain.PostLikeState;
+import com.study.studyproject.postlike.dto.PostLikeOneResponseDto;
 import com.study.studyproject.postlike.repository.PostLikeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +24,31 @@ import static com.study.studyproject.global.exception.ex.ErrorCode.*;
 @Transactional
 @RequiredArgsConstructor
 public class PostLikeService {
-
-    private final MemberRepository memberRepository;
     private final PostLikeRepository postLikeRepository;
     private final BoardRepository boardRepository;
+
+
+    public PostLikeOneResponseDto getPostLikeForOneBoard(Member member, Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+        Long postLikeId = findByPostLikeId(member, boardId);
+        String  postLikeValue = findByPostLike(member, board);
+        return PostLikeOneResponseDto.of(postLikeValue,postLikeId);
+    }
+
+    public Long findByPostLikeId(Member member, long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD));
+        Optional<PostLike> byBoardAndMember = postLikeRepository.findByBoardAndMember(board, member);
+        if (byBoardAndMember.isPresent()) {
+            return byBoardAndMember.get().getId();
+        }
+        return null;
+    }
+
+    private String findByPostLike(Member member, Board board) {
+            Optional<PostLike> byBoardAndMember = postLikeRepository.findByBoardAndMember(board, member);
+            return byBoardAndMember.isPresent() ? PostLikeState.LIKING.getName() : PostLikeState.LIKE.getName();
+    }
+
 
     public GlobalResultDto postLikeSave(Long boardId ,Member member) {
         Board board = boardRepository.findById(boardId).orElseThrow(()-> new NotFoundException(NOT_FOUND_BOARD));
@@ -42,4 +64,6 @@ public class PostLikeService {
         postLikeRepository.deleteById(postLikeId);
         return new GlobalResultDto("관심글이 삭제되었습니다.", HttpStatus.OK.value());
     }
+
+
 }

--- a/src/main/java/com/study/studyproject/reply/controller/ReplyController.java
+++ b/src/main/java/com/study/studyproject/reply/controller/ReplyController.java
@@ -1,18 +1,15 @@
 package com.study.studyproject.reply.controller;
 
-import com.study.studyproject.global.auth.UserDetailsImpl;
 import com.study.studyproject.global.jwt.JwtUtil;
 import com.study.studyproject.reply.dto.ReplyRequestDto;
+import com.study.studyproject.reply.dto.ReplyResponseDto;
 import com.study.studyproject.reply.dto.UpdateReplyRequest;
-import com.study.studyproject.reply.service.ReplyService;
 import com.study.studyproject.reply.service.ReplyServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +21,13 @@ public class ReplyController {
 
     private final ReplyServiceImpl replyService;
     private final JwtUtil jwtUtil;
+
+    @GetMapping("/view/{boardId}")
+    @Operation(summary = "댓글 조회", description = "댓글 조회")
+    public ResponseEntity<ReplyResponseDto> selectReply(@PathVariable("boardId") Long boardId) {
+        return ResponseEntity.ok(replyService.getRepliesForOneBoard(boardId));
+    }
+
     @PostMapping
     @Operation(summary = "댓글 추가", description = "댓글 추가")
     public void insertReply(@RequestHeader("Access_Token") String token

--- a/src/main/java/com/study/studyproject/reply/domain/Reply.java
+++ b/src/main/java/com/study/studyproject/reply/domain/Reply.java
@@ -63,7 +63,6 @@ public class Reply extends BaseTimeEntity {
 
 
 
-
     public static Reply toEntity(ReplyRequestDto replyRequestDto, Board board, Member member) {
         return Reply.builder()
                 .content(replyRequestDto.getContent())
@@ -97,6 +96,10 @@ public class Reply extends BaseTimeEntity {
 
     public void ChangeIsDeleted(Boolean deleted) {
         isDeleted = deleted;
+    }
+
+    public static boolean isReplies(List<Reply> replies) {
+        return replies.size() != 0;
     }
 
 

--- a/src/main/java/com/study/studyproject/reply/service/ReplyService.java
+++ b/src/main/java/com/study/studyproject/reply/service/ReplyService.java
@@ -1,10 +1,12 @@
 package com.study.studyproject.reply.service;
 
 import com.study.studyproject.reply.dto.ReplyRequestDto;
+import com.study.studyproject.reply.dto.ReplyResponseDto;
 import com.study.studyproject.reply.dto.UpdateReplyRequest;
 
 public interface ReplyService {
 
+    ReplyResponseDto getRepliesForOneBoard(Long boardId) ;
 
     void insert(Long memberId, ReplyRequestDto replyRequestDto);
 

--- a/src/test/java/com/study/studyproject/board/service/BoardServiceTest.java
+++ b/src/test/java/com/study/studyproject/board/service/BoardServiceTest.java
@@ -124,10 +124,8 @@ class BoardServiceTest {
 
         TokenDtoResponse allToken = jwtUtil.createAllToken("jacom2@naver.com", member1.getId());
 
-        UserDetailsImpl userDetails = new UserDetailsImpl(null, Role.ROLE_GUEST, 0L);
-        //when
         String postLike = "";
-        BoardOneResponseDto boardOneResponseDto = boardService.boardOne(board.getId(), userDetails);
+        BoardOneResponseDto boardOneResponseDto = boardService.boardOne(board.getId(), null);
 
         //then
         assertThat(boardOneResponseDto.getContent()).isEqualTo(board.getContent());
@@ -169,8 +167,6 @@ class BoardServiceTest {
         TokenDtoResponse allToken = jwtUtil.createAllToken("jacom2@naver.com", member1.getId());
         BoardOneResponseDto boardOneResponseDto = boardService.boardOne(board.getId(),  userDetails);
 
-        assertThat(boardOneResponseDto.getReplyResponseDto().getGetTotal()).isEqualTo(replies.size());
-        assertThat(boardOneResponseDto.getReplyResponseDto().getReplies().get(0).getChildren()).hasSize(3);
 
         assertThat(boardOneResponseDto.getContent()).isEqualTo(board.getContent());
         assertThat(boardOneResponseDto.getTitle()).isEqualTo(board.getTitle());
@@ -209,9 +205,6 @@ class BoardServiceTest {
 
         //when
         BoardOneResponseDto boardOneResponseDto = boardService.boardOne( board.getId(), userDetails);
-
-        assertThat(boardOneResponseDto.getReplyResponseDto().getGetTotal()).isEqualTo(replies.size());
-        assertThat(boardOneResponseDto.getReplyResponseDto().getReplies().get(0).getChildren()).hasSize(3);
 
         assertThat(boardOneResponseDto.getContent()).isEqualTo(board.getContent());
         assertThat(boardOneResponseDto.getTitle()).isEqualTo(board.getTitle());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,5 @@
+location: http://localhost:3000/
+
 spring:
   profiles:
     active: test
@@ -24,7 +26,37 @@ spring:
         format_sql: true
         show_sql: true
     defer-datasource-initialization: true
-
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            authorization-grant-type: authorization_code
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            scope:
+              - account_email
+              - profile_nickname
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: name, email
+        provider:
+          naver:
+            authorization_uri: https://nid.naver.com/oauth2.0/authorize
+            token_uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 jwt:
   secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK


### PR DESCRIPTION
## 개요
- closed :#87
 - 문제 : 게시글 상세보기에서 하나의 메서드에 게시글 조회, 댓글 조회, 관심 여부 조회 관리하여 복잡한 메서드 작성 및 다양한 기능이 결합된 메서드로 테스트작성이 어렵다는 단점 발생 

- 게시글 상세보기에서 단일 책임 원칙을 준수하여 게시글 조회, 댓글 조회, 관심 여부 조회 각 api로 나눔으로써 유지보수 용이 및 코드의 재사용성을 높임

## 작업사항
해결 : 각 API를 별도의 서비스로 분리하고 각 서비스에서 구현하여 SPR준수

## 변경로직(optional)
- 내용을 적어주세요.

