### PR TITLE
fix : 대소문자 구분하지 않도록 변경

### DIFF
--- a/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
+++ b/src/main/java/com/study/studyproject/global/jwt/JwtFilter.java
@@ -37,8 +37,6 @@ public class JwtFilter extends OncePerRequestFilter {
         String accessToken = jwtUtil.getHeaderToken(request, JwtUtil.ACCESS_TOKEN);
 
         accessToken = jwtUtil.resolveToken(accessToken);
-        if (accessToken == null) {
-        }
         if (accessToken != null ) {//  회원일 경우,
             if (jwtUtil.AccessTokenValidation(accessToken)) { // AccessToken 사용 가능
                 String emailFromToken = jwtUtil.getEmailFromToken(accessToken);

--- a/src/main/java/com/study/studyproject/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/study/studyproject/global/oauth/CustomOAuth2UserService.java
@@ -58,10 +58,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 
     private SocialType getSocialType(String registrationId) {
-        if ("NAVER".equals(registrationId)) {
+        if ("NAVER".equalsIgnoreCase(registrationId)) {
             return NAVER;
         }
-        if ("KAKAO".equals(registrationId)) {
+        if ("KAKAO".equalsIgnoreCase((registrationId))) {
             return KAKAO;
         }
 


### PR DESCRIPTION
## 개요
- closed: #91 
- registrationId값은 소문자로 받아 NAVER인지를 비교할 때, 대소문자 구분없이 만듦

## 작업사항

- equals()에서 equalsIgnoreCase()으로 변경

## 변경로직(optional)
- 내용을 적어주세요.

